### PR TITLE
Fix single line diagram label style

### DIFF
--- a/src/components/single-line-diagram.js
+++ b/src/components/single-line-diagram.js
@@ -22,6 +22,11 @@ const useStyles = makeStyles(theme => ({
     diagram: {
         width: 800,
         height: 600,
+        "& .component-label": {
+            fill: theme.palette.text.primary,
+            "font-size": 12,
+            "font-family": theme.typography.fontFamily
+        }
     },
     close: {
         padding: 0


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fearture


**What is the new behavior (if this is a feature change)?**
Single line diagram style is adapted to current theme.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
