### PR TITLE
Use a better maxzoom

### DIFF
--- a/src/components/network/network-map.js
+++ b/src/components/network/network-map.js
@@ -149,7 +149,7 @@ const NetworkMap = (props) => {
         longitude: props.initialPosition[0],
         latitude: props.initialPosition[1],
         zoom: props.initialZoom,
-        maxZoom: 16,
+        maxZoom: 12,
         pitch: 0,
         bearing: 0
     };


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
At max zoom, a substations use 80% of the screen showing a big colored circle


**What is the new behavior (if this is a feature change)?**
at max zoom, the substation uses a normal chunk of the screen


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
