### PR TITLE
keep_the_same_zoom_level_for_substation_with_an_activable_scroll

### DIFF
--- a/src/components/single-line-diagram.js
+++ b/src/components/single-line-diagram.js
@@ -16,14 +16,20 @@ import {makeStyles} from "@material-ui/core/styles";
 import Typography from '@material-ui/core/Typography';
 
 const useStyles = makeStyles(theme => ({
+    div: {
+        overflowX: 'auto',
+        overflowY: 'auto'
+    },
     diagram: {
-        width: 800,
-        height: 600,
+        maxWidth: 800,
+        maxHeight: 700,
+        overflowX: 'auto',
+        overflowY: 'auto',
         "& .component-label": {
             fill: theme.palette.text.primary,
             "font-size": 12,
             "font-family": theme.typography.fontFamily
-        }
+        },
     },
     close: {
         padding: 0
@@ -33,13 +39,16 @@ const useStyles = makeStyles(theme => ({
 const SingleLineDiagram = (props) => {
 
     useEffect(() => {
-        var svg = document.getElementById("sld-svg").getElementsByTagName("svg")[0];
+        let svg = document.getElementById("sld-svg").getElementsByTagName("svg")[0];
         if (svg) {
-            svg.style.height = "100%";
-            svg.style.width = "100%";
-            var bbox = svg.getBBox();
-            svg.setAttribute("viewBox", 0 + " " + 0 + " " + (bbox.width + 20) + " " + (bbox.height + 20));
-        }
+            let bbox = svg.getBBox();
+            let svgWidth = bbox.width + 20;
+            let svgHeight = bbox.height + 20;
+            svg.setAttribute("width", svgWidth);
+            svg.setAttribute("height", svgHeight);
+            svg.style.width = svgWidth;
+            svg.style.height = svgHeight;
+       }
     }, [props.svg]);
 
     const classes = useStyles();
@@ -60,7 +69,7 @@ const SingleLineDiagram = (props) => {
                     <CloseIcon/>
                 </IconButton>
             </Box>
-            <div id="sld-svg" style={{height : '100%'}} dangerouslySetInnerHTML={{__html:props.svg}}/>
+            <div id="sld-svg" style={{height : '100%'}} className={classes.div} dangerouslySetInnerHTML={{__html:props.svg}}/>
         </Paper>
     );
 };

--- a/src/components/single-line-diagram.js
+++ b/src/components/single-line-diagram.js
@@ -39,11 +39,11 @@ const useStyles = makeStyles(theme => ({
 const SingleLineDiagram = (props) => {
 
     useEffect(() => {
-        let svg = document.getElementById("sld-svg").getElementsByTagName("svg")[0];
+        const svg = document.getElementById("sld-svg").getElementsByTagName("svg")[0];
         if (svg) {
-            let bbox = svg.getBBox();
-            let svgWidth = bbox.width + 20;
-            let svgHeight = bbox.height + 20;
+            const bbox = svg.getBBox();
+            const svgWidth = bbox.width + 20;
+            const svgHeight = bbox.height + 20;
             svg.setAttribute("width", svgWidth);
             svg.setAttribute("height", svgHeight);
             svg.style.width = svgWidth;


### PR DESCRIPTION
Setting the svg height and width attribute from the svg bounding box, so this will dynamically adjust the size of the embedding window.
Defining a max width and max height for this window.
Adding scrollbars when necessary to scroll the svg inside the window.

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature

**What is the current behavior?** *(You can also link to an open issue here)*
A substation is always drawn in a fixed size window and the svg is scaled to fit into this window

**What is the new behavior (if this is a feature change)?**
A substation is now drawn in a dynamically calculated size window (with a maximum fixed size) and the svg is not scaled anymore, so the zoom level is always kept.
Scrollbars are added when necessary to view all svg parts.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
