### PR TITLE
Fix missing labels on start when viewing small networks

### DIFF
--- a/src/components/network/network-map.js
+++ b/src/components/network/network-map.js
@@ -86,6 +86,7 @@ const NetworkMap = (props) => {
                             bearing: deck.viewState.bearing
                     };
                     deck.setProps({});
+                    deck._onViewStateChange({viewState: deck.viewState});
                 }
                 setCentered(true);
             }


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug Fix


**What is the current behavior?** *(You can also link to an open issue here)*
Labels are not shown on a small networks at startup. They appear when you pan/zoom once


**What is the new behavior (if this is a feature change)?**
Labels are shown


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO