### PR TITLE
study-pane: handle network errors in svg fetch

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -30,6 +30,7 @@
   "useName": "Use the name instead of the identifier",
 
   "studyNotFound": "Study '{studyName}' has not been found",
+  "svgNotFound": "Diagram has not been found: {error}; {svgUrl} ",
 
   "parameters": "Parameters",
   "theme": "Theme",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -30,6 +30,7 @@
   "useName": "Utiliser le nom à la place de l'identifiant",
 
   "studyNotFound": "L'étude ''{studyName}'' n'a pas été trouvée",
+  "svgNotFound": "L'image poste n'a pas été trouvée : {error}; {svgUrl} ",
 
   "parameters": "Paramètres",
   "theme": "Thème",


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature

**What is the current behavior?** *(You can also link to an open issue here)*
When a network or server error on svg fetching happens, nothing happens in the browser


**What is the new behavior (if this is a feature change)?**
When a network or server error on svg fetching happens, an error is shown in the browser


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*

