### PR TITLE
single-line-diagram, display diagram of next voltage level on click

### DIFF
--- a/src/components/single-line-diagram.js
+++ b/src/components/single-line-diagram.js
@@ -58,7 +58,7 @@ const SvgNotFound = (props) => {
     );
 };
 
-const nosvg = {svg: null, error: null, svgUrl: null};
+const nosvg = {svg: null, metadata: null, error: null, svgUrl: null};
 
 const SingleLineDiagram = (props) => {
 
@@ -67,12 +67,12 @@ const SingleLineDiagram = (props) => {
     useEffect(() => {
         if (props.svgUrl) {
             fetchSvg(props.svgUrl)
-                .then(svg => {
-                    setSvg({svg, error:null, svgUrl: props.svgUrl});
+                .then(data => {
+                    setSvg({svg: data.svg, metadata: data.metadata, error: null, svgUrl: props.svgUrl});
                 })
                 .catch(function(error) {
                     console.error(error.message);
-                    setSvg({svg: null, error, svgUrl: props.svgUrl});
+                    setSvg({svg: null, metadata: null, error, svgUrl: props.svgUrl});
                 });
         } else {
             setSvg(nosvg);
@@ -81,14 +81,23 @@ const SingleLineDiagram = (props) => {
 
     useEffect(() => {
         if (svg.svg) {
-            const svg = document.getElementById("sld-svg").getElementsByTagName("svg")[0];
-            const bbox = svg.getBBox();
+            const svgEl = document.getElementById("sld-svg").getElementsByTagName("svg")[0];
+            const bbox = svgEl.getBBox();
             const svgWidth = bbox.width + 20;
             const svgHeight = bbox.height + 20;
-            svg.setAttribute("width", svgWidth);
-            svg.setAttribute("height", svgHeight);
-            svg.style.width = svgWidth;
-            svg.style.height = svgHeight;
+            svgEl.setAttribute("width", svgWidth);
+            svgEl.setAttribute("height", svgHeight);
+            svgEl.style.width = svgWidth;
+            svgEl.style.height = svgHeight;
+            const elements = svg.metadata.nodes.filter(el => el.nextVId !== null);
+            elements.forEach(el => {
+                const domEl = document.getElementById(el.id);
+                domEl.style.cursor = "pointer";
+                domEl.addEventListener("click", function(e) {
+                    const id = e.target.parentElement.id;
+                    const meta = svg.metadata.nodes.find( other => other.id === id );
+                    props.onNextVoltageLevelClick(meta.nextVId);
+                })});
         }
     }, [svg]);
 

--- a/src/components/study-pane.js
+++ b/src/components/study-pane.js
@@ -181,6 +181,7 @@ const StudyPane = () => {
                             voltageLevelId &&
                             <div style={{ position: "absolute", left: 10, top: 10, zIndex: 1 }}>
                                 <SingleLineDiagram onClose={() => closeVoltageLevelDiagram()}
+                                                   onNextVoltageLevelClick={(nextId) => setVoltageLevelId(nextId)}
                                                    diagramTitle={useName && voltageLevel ? voltageLevel.name : voltageLevelId}
                                                    svgUrl={getVoltageLevelSingleLineDiagram(studyName, voltageLevelId, useName)} />
                             </div>

--- a/src/utils/rest-api.js
+++ b/src/utils/rest-api.js
@@ -23,14 +23,14 @@ export function fetchCases() {
 
 export function getVoltageLevelSingleLineDiagram(studyName, voltageLevelId, useName) {
     console.info(`Getting url of voltage level diagram '${voltageLevelId}' of study '${studyName}'...`);
-    return process.env.REACT_APP_API_STUDY_SERVER + "/v1/studies/" + studyName + "/network/voltage-levels/" + voltageLevelId + "/svg?useName=" + useName;
+    return process.env.REACT_APP_API_STUDY_SERVER + "/v1/studies/" + studyName + "/network/voltage-levels/" + voltageLevelId + "/svg-and-metadata?useName=" + useName;
 }
 
 export function fetchSvg(svgUrl) {
     console.debug(svgUrl);
     return fetch(svgUrl)
         .then(response => response.ok ?
-                            response.text() :
+                            response.json() :
                             response.json().then( error =>
                                 Promise.reject(new Error(error.error))));
 }


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
click on a line or transformer in the sld, nothing happens


**What is the new behavior (if this is a feature change)?**
click on a line or transformer, it displays the next voltage id


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

**Other information**:
This needs https://github.com/powsybl/powsybl-study-server/pull/10