### PR TITLE
Network filtering according to nominal voltages

### DIFF
--- a/src/components/network/network.js
+++ b/src/components/network/network.js
@@ -31,6 +31,8 @@ export default class Network {
 
     voltageLevelsById = new Map();
 
+    linesByNominalVoltage = new Map();
+
     setSubstations(substations) {
         this.substations = substations;
 
@@ -60,6 +62,17 @@ export default class Network {
 
     setLines(lines) {
         this.lines = lines;
+        this.lines.forEach(line => {
+            const vl = this.getVoltageLevel(line.voltageLevelId1) || this.getVoltageLevel(line.voltageLevelId2);
+            if (vl) {
+                let list = this.linesByNominalVoltage.get(vl.nominalVoltage);
+                if (!list) {
+                    list = [];
+                    this.linesByNominalVoltage.set(vl.nominalVoltage, list);
+                }
+                list.push(line);
+            }
+        })
     }
 
     getVoltageLevels() {

--- a/src/components/network/nominal-voltage-filter.js
+++ b/src/components/network/nominal-voltage-filter.js
@@ -20,6 +20,7 @@ import Paper from "@material-ui/core/Paper";
 
 const useStyles = makeStyles(theme => ({
     nominalVoltageZone: {
+        minWidth: 90,
         maxHeight : 300,
         overflowY : 'auto',
     },

--- a/src/components/network/nominal-voltage-filter.js
+++ b/src/components/network/nominal-voltage-filter.js
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import React, {useEffect, useState} from 'react';
+import PropTypes from "prop-types";
+
+import {makeStyles} from "@material-ui/core/styles";
+
+import Network from "./network";
+
+import List from "@material-ui/core/List";
+import ListItem from "@material-ui/core/ListItem";
+import Checkbox from "@material-ui/core/Checkbox";
+import ListItemText from "@material-ui/core/ListItemText";
+import Paper from "@material-ui/core/Paper";
+
+const useStyles = makeStyles(theme => ({
+    nominalVoltageZone: {
+        maxHeight : 300,
+        overflowY : 'auto',
+    },
+    nominalVoltageItem: {
+        padding: '0px',
+    },
+    nominalVoltageCheck: {
+        size: 'small',
+        padding: '0px',
+    },
+    nominalVoltageText : {
+        fontSize: 12
+    }
+}));
+
+const NominalVoltageFilter = (props) => {
+    const classes = useStyles();
+    const [checkedNominalVoltages, setCheckedNominalVoltages] = useState([]);
+    const [nominalVoltages, setNominalVoltages] = useState([]);
+
+    useEffect(() => {
+        if (props.network) {
+            setNominalVoltages(Array.from(props.network.voltageLevelsByNominalVoltage.keys()).sort((a, b) => b - a));
+        }
+        if (props.filteredVoltageLevels) {
+            setCheckedNominalVoltages(props.filteredVoltageLevels);
+        }
+    }, [props.network, props.filteredVoltageLevels]);
+
+    const handleToggle = value => () => {
+        const currentIndex = checkedNominalVoltages.indexOf(value);
+        const newChecked = [...checkedNominalVoltages];
+
+        if (currentIndex === -1) {
+            newChecked.push(value);
+        } else {
+            newChecked.splice(currentIndex, 1);
+        }
+        setCheckedNominalVoltages(newChecked);
+
+        if (props.onNominalVoltageFilter !== null) {
+            props.onNominalVoltageFilter(value);
+        }
+    };
+
+    return (
+        <Paper>
+            <List className={classes.nominalVoltageZone}> {
+                nominalVoltages.map(value => {
+                    return (
+                        <ListItem className={classes.nominalVoltageItem}
+                            key={value}
+                            button
+                            onClick={handleToggle(value)}
+                        >
+                            <Checkbox color="default" className={classes.nominalVoltageCheck} checked={checkedNominalVoltages.indexOf(value) !== -1}/>
+                            <ListItemText className={classes.nominalVoltageText} disableTypography primary={`${value}`}/>
+                        </ListItem>
+                    );
+                })}
+            </List>
+        </Paper>
+    )
+};
+
+NominalVoltageFilter.defaultProps = {
+    network: null,
+    filteredVoltageLevels: null,
+    onNominalVoltageFilter: null
+};
+
+NominalVoltageFilter.propTypes = {
+    network: PropTypes.instanceOf(Network),
+    filteredVoltageLevels: PropTypes.instanceOf(Array),
+    onNominalVoltageFilter: PropTypes.func
+};
+
+export default NominalVoltageFilter;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Feature

**What is the current behavior?** *(You can also link to an open issue here)*
No possibility to filter the network elements on the map (substations, labels, lines) by nominal voltage levels


**What is the new behavior (if this is a feature change)?**
A new graphical component allows the user to check/uncheck the nominal voltage levels and filter the network elements on the map


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
