### PR TITLE
go to the main page of study-app when clicking on the logo

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "react-scripts": "3.3.0",
     "react-window": "^1.8.5",
     "redux": "^4.0.5",
-    "typeface-roboto": "0.0.75"
+    "typeface-roboto": "0.0.75",
+    "prop-types": "15.7.2",
+    "react-router": "^5.1.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/top-bar.js
+++ b/src/components/top-bar.js
@@ -27,9 +27,14 @@ const useStyles = makeStyles(theme => ({
     logo: {
         width: 48,
         height: 48,
+        float: 'left'
     },
     title: {
-        marginLeft: 18
+        marginLeft: 18,
+        float: 'right'
+    },
+    logoZone: {
+        cursor: 'pointer'
     }
 }));
 
@@ -52,10 +57,12 @@ const TopBar = (props) => {
     return (
         <AppBar position="static" color="default" className={classes.appBar}>
             <Toolbar>
-                <PowsyblLogo className={classes.logo} onClick={onLogoClick}/>
-                <Typography variant="h6" className={classes.title}>
-                    <FormattedMessage id="appName"/>
-                </Typography>
+                <div className={classes.logoZone} onClick={onLogoClick}>
+                    <PowsyblLogo className={classes.logo}/>
+                    <Typography variant="h6" className={classes.title}>
+                        <FormattedMessage id="appName"/>
+                    </Typography>
+                </div>
                 <div className={classes.grow} />
                 <IconButton aria-label="Parameters" color="inherit" onClick={onParametersClick}>
                     <SettingsIcon />

--- a/src/components/top-bar.js
+++ b/src/components/top-bar.js
@@ -27,13 +27,10 @@ const useStyles = makeStyles(theme => ({
     logo: {
         width: 48,
         height: 48,
-        float: 'left'
+        cursor: 'pointer'
     },
     title: {
         marginLeft: 18,
-        float: 'right'
-    },
-    logoZone: {
         cursor: 'pointer'
     }
 }));
@@ -57,15 +54,13 @@ const TopBar = (props) => {
     return (
         <AppBar position="static" color="default" className={classes.appBar}>
             <Toolbar>
-                <div className={classes.logoZone} onClick={onLogoClick}>
-                    <PowsyblLogo className={classes.logo}/>
-                    <Typography variant="h6" className={classes.title}>
-                        <FormattedMessage id="appName"/>
-                    </Typography>
-                </div>
-                <div className={classes.grow} />
+                <PowsyblLogo className={classes.logo} onClick={onLogoClick}/>
+                <Typography variant="h6" className={classes.title} onClick={onLogoClick}>
+                    <FormattedMessage id="appName"/>
+                </Typography>
+                <div className={classes.grow}/>
                 <IconButton aria-label="Parameters" color="inherit" onClick={onParametersClick}>
-                    <SettingsIcon />
+                    <SettingsIcon/>
                 </IconButton>
             </Toolbar>
         </AppBar>

--- a/src/components/top-bar.js
+++ b/src/components/top-bar.js
@@ -20,7 +20,7 @@ import SettingsIcon from '@material-ui/icons/Settings';
 import {ReactComponent as PowsyblLogo} from "../images/powsybl_logo.svg";
 import PropTypes from "prop-types";
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles(() => ({
     grow: {
         flexGrow: 1,
     },
@@ -49,7 +49,7 @@ const TopBar = (props) => {
 
     const onLogoClick = () => {
         history.replace("/");
-    }
+    };
 
     return (
         <AppBar position="static" color="default" className={classes.appBar}>

--- a/src/components/top-bar.js
+++ b/src/components/top-bar.js
@@ -8,6 +8,7 @@
 import React from "react";
 
 import {FormattedMessage} from "react-intl";
+import {useHistory} from 'react-router-dom';
 
 import AppBar from "@material-ui/core/AppBar";
 import IconButton from "@material-ui/core/IconButton";
@@ -36,16 +37,22 @@ const TopBar = (props) => {
 
     const classes = useStyles();
 
+    const history = useHistory();
+
     const onParametersClick = () => {
       if (props.onParametersClick) {
           props.onParametersClick();
       }
     };
 
+    const onLogoClick = () => {
+        history.replace("/");
+    }
+
     return (
         <AppBar position="static" color="default" className={classes.appBar}>
             <Toolbar>
-                <PowsyblLogo className={classes.logo}/>
+                <PowsyblLogo className={classes.logo} onClick={onLogoClick}/>
                 <Typography variant="h6" className={classes.title}>
                     <FormattedMessage id="appName"/>
                 </Typography>


### PR DESCRIPTION
Signed-off-by: Franck LECUYER <franck.lecuyer@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Nothing happens when the user clicks on the application logo


**What is the new behavior (if this is a feature change)?**
When the user click on the application logo, the main page is now displayed


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
