### PR TITLE
center map on substation on user clicks

### DIFF
--- a/src/components/network/network-explorer.js
+++ b/src/components/network/network-explorer.js
@@ -22,6 +22,9 @@ import TextField from '@material-ui/core/TextField';
 import {FixedSizeList as List} from 'react-window';
 
 import Network from "./network";
+import ListItemText from "@material-ui/core/ListItemText";
+import IconButton from "@material-ui/core/IconButton";
+import GpsFixedIcon from '@material-ui/icons/GpsFixed';
 import Divider from "@material-ui/core/Divider";
 import {AutoSizer} from "react-virtualized";
 
@@ -34,7 +37,7 @@ const useStyles = makeStyles(theme => ({
     },
 }));
 
-const NetworkExplorer = ({network, onVoltageLevelClick}) => {
+const NetworkExplorer = ({network, onVoltageLevelDisplayClick, onVoltageLevelFocusClick}) => {
 
     const intl = useIntl();
 
@@ -59,22 +62,33 @@ const NetworkExplorer = ({network, onVoltageLevelClick}) => {
 
     useEffect(() => {
         if (currentVoltageLevel !== null) {
-            onVoltageLevelClick(currentVoltageLevel.id, currentVoltageLevel.name);
+            onVoltageLevelDisplayClick(currentVoltageLevel.id, currentVoltageLevel.name);
+            onVoltageLevelFocusClick(currentVoltageLevel.id, currentVoltageLevel.name);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [useName]);
 
-    function onClickHandler(index) {
-        if (onVoltageLevelClick !== null) {
+    function onDisplayClickHandler(index) {
+        if (onVoltageLevelDisplayClick !== null) {
             const vl = filteredVoltageLevels[index];
-            onVoltageLevelClick(vl.id);
+            onVoltageLevelDisplayClick(vl.id);
             setCurrentVoltageLevel(vl);
         }
     }
 
+    function onFocusClickHandler(index) {
+        if (onVoltageLevelFocusClick !== null) {
+            const vl = filteredVoltageLevels[index];
+            onVoltageLevelFocusClick(vl.id);
+        }
+    }
+
     const Row = ({ index, style }) => (
-        <ListItem button style={style} key={index} onClick={() => onClickHandler(index)}>
-            {useName ? filteredVoltageLevels[index].name : filteredVoltageLevels[index].id}
+        <ListItem button style={style} key={index} >
+            <ListItemText primary={useName ? filteredVoltageLevels[index].name : filteredVoltageLevels[index].id} onClick={() => onDisplayClickHandler(index)} />
+            <IconButton onClick={() => onFocusClickHandler(index)}>
+                <GpsFixedIcon />
+            </IconButton>
         </ListItem>
     );
 

--- a/src/components/network/network-explorer.js
+++ b/src/components/network/network-explorer.js
@@ -103,7 +103,7 @@ const NetworkExplorer = ({network, onVoltageLevelDisplayClick, onVoltageLevelFoc
 
     const voltagelevelInfo = index => {
         if (network.getSubstation(filteredVoltageLevels[index].substationId)) {
-            return network.getSubstation(filteredVoltageLevels[index].substationId).countryName + " - " + filteredVoltageLevels[index].nominalVoltage + " kV";
+            return filteredVoltageLevels[index].nominalVoltage + " kV — " + network.getSubstation(filteredVoltageLevels[index].substationId).countryName;
         }
     };
 

--- a/src/components/network/network-map.js
+++ b/src/components/network/network-map.js
@@ -67,12 +67,12 @@ const NetworkMap = (props) => {
             //TODO, replace the next lines with setProps( { initialViewState } ) when we upgrade to 8.1.0
             //see https://github.com/uber/deck.gl/pull/4038
             //This is a hack because it accesses the properties of deck directly but for now it works
-            if ((!centered.centered || (props.centeredSubstationId && props.centeredSubstationId != centered.lastCenteredSubstation))
+            if ((!centered.centered || (props.centeredSubstationId && props.centeredSubstationId !== centered.lastCenteredSubstation))
                  && deck !== null && deck.viewManager != null && props.geoData !== null) {
                 if (props.geoData.substationPositionsById.size > 0) {
                     if (props.centeredSubstationId) {
                         const geodata = props.geoData.substationPositionsById.get(props.centeredSubstationId);
-                        const copyViewState = lastViewStateRef.current || deck.viewState
+                        const copyViewState = lastViewStateRef.current || deck.viewState;
                         const newViewState = {
                                 longitude: geodata.lon,
                                 latitude: geodata.lat,
@@ -281,7 +281,8 @@ NetworkMap.defaultProps = {
     labelsZoomThreshold: 7,
     initialZoom: 5,
     filteredNominalVoltages: null,
-    initialPosition: [0, 0]
+    initialPosition: [0, 0],
+    centeredSubstationId: null
 };
 
 NetworkMap.propTypes = {
@@ -291,7 +292,8 @@ NetworkMap.propTypes = {
     initialZoom: PropTypes.number.isRequired,
     filteredNominalVoltages: PropTypes.array,
     initialPosition: PropTypes.arrayOf(PropTypes.number).isRequired,
-    onSubstationClick: PropTypes.func
+    onSubstationClick: PropTypes.func,
+    centeredSubstationId: PropTypes.string
 };
 
 export default React.memo(NetworkMap);

--- a/src/components/network/network-map.js
+++ b/src/components/network/network-map.js
@@ -5,9 +5,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, {useState} from 'react';
+import React, {useRef, useState} from 'react';
 import PropTypes from 'prop-types';
 import {_MapContext as MapContext, NavigationControl, StaticMap} from 'react-map-gl';
+import {FlyToInterpolator} from '@deck.gl/core';
 import DeckGL from '@deck.gl/react';
 import {PathLayer, ScatterplotLayer, TextLayer} from '@deck.gl/layers';
 
@@ -31,7 +32,8 @@ const NetworkMap = (props) => {
     const [labelsVisible, setLabelsVisible] = useState(false);
 
     const [deck, setDeck] = useState(null);
-    const [centered, setCentered] = useState(false);
+    const [centered, setCentered] = useState({lastCenteredSubstation: null, centered: false});
+    const lastViewStateRef = useRef(null);
 
     const [tooltip, setTooltip] = useState({});
 
@@ -62,39 +64,64 @@ const NetworkMap = (props) => {
     // we get the ref to the deck and it has not yet initialized..)
     function onAfterRender() {
             //use centered and deck to execute this block only once when the data is ready and deckgl is initialized
-            if (!centered && deck !== null && deck.viewManager != null && props.geoData !== null) {
+            //TODO, replace the next lines with setProps( { initialViewState } ) when we upgrade to 8.1.0
+            //see https://github.com/uber/deck.gl/pull/4038
+            //This is a hack because it accesses the properties of deck directly but for now it works
+            if ((!centered.centered || (props.centeredSubstationId && props.centeredSubstationId != centered.lastCenteredSubstation))
+                 && deck !== null && deck.viewManager != null && props.geoData !== null) {
                 if (props.geoData.substationPositionsById.size > 0) {
-                    const coords = Array.from(props.geoData.substationPositionsById.entries()).map(x => x[1]);
-                    const maxlon = Math.max.apply(null, coords.map(x => x.lon));
-                    const minlon = Math.min.apply(null, coords.map(x => x.lon));
-                    const maxlat = Math.max.apply(null, coords.map(x => x.lat));
-                    const minlat = Math.min.apply(null, coords.map(x => x.lat));
-                    const marginlon = (maxlon - minlon)/10;
-                    const marginlat = (maxlat - minlat)/10;
-                    const viewport = deck.getViewports()[0];
-                    const boundedViewport = viewport.fitBounds([
-                            [minlon - marginlon/2, minlat - marginlat/2],
-                            [maxlon + marginlon/2, maxlat + marginlat/2]
-                    ]);
-                    //TODO, replace the next lines with setProps( { initialViewState } ) when we upgrade to 8.1.0
-                    //see https://github.com/uber/deck.gl/pull/4038
-                    //This is a hack because it accesses the properties of deck directly but for now it works
-                    deck.viewState = {
-                            longitude: boundedViewport.longitude,
-                            latitude: boundedViewport.latitude,
-                            zoom: Math.min(deck.viewState.maxZoom, boundedViewport.zoom),
-                            maxZoom: deck.viewState.maxZoom,
-                            pitch: deck.viewState.pitch,
-                            bearing: deck.viewState.bearing
-                    };
-                    deck.setProps({});
-                    deck._onViewStateChange({viewState: deck.viewState});
+                    if (props.centeredSubstationId) {
+                        const geodata = props.geoData.substationPositionsById.get(props.centeredSubstationId);
+                        const copyViewState = lastViewStateRef.current || deck.viewState
+                        const newViewState = {
+                                longitude: geodata.lon,
+                                latitude: geodata.lat,
+                                zoom: copyViewState.zoom,
+                                maxZoom: deck.viewState.maxZoom,
+                                pitch: copyViewState.pitch,
+                                bearing: copyViewState.bearing
+                        };
+                        // if this is not the page load, use a fly to animation. On page load, we want to center directly
+                        if (centered.centered) {
+                            newViewState.transitionDuration = 2000;
+                            newViewState.transitionInterpolator = new FlyToInterpolator();
+                        }
+                        deck.viewState = newViewState;
+                        deck.setProps({});
+                        deck._onViewStateChange({viewState: deck.viewState});
+                        setCentered({lastCenteredSubstation: props.centeredSubstationId, centered: true});
+                    } else {
+                        const coords = Array.from(props.geoData.substationPositionsById.entries()).map(x => x[1]);
+                        const maxlon = Math.max.apply(null, coords.map(x => x.lon));
+                        const minlon = Math.min.apply(null, coords.map(x => x.lon));
+                        const maxlat = Math.max.apply(null, coords.map(x => x.lat));
+                        const minlat = Math.min.apply(null, coords.map(x => x.lat));
+                        const marginlon = (maxlon - minlon)/10;
+                        const marginlat = (maxlat - minlat)/10;
+                        const viewport = deck.getViewports()[0];
+                        const boundedViewport = viewport.fitBounds([
+                                [minlon - marginlon/2, minlat - marginlat/2],
+                                [maxlon + marginlon/2, maxlat + marginlat/2]
+                        ]);
+                        deck.viewState = {
+                                longitude: boundedViewport.longitude,
+                                latitude: boundedViewport.latitude,
+                                zoom: Math.min(deck.viewState.maxZoom, boundedViewport.zoom),
+                                maxZoom: deck.viewState.maxZoom,
+                                pitch: deck.viewState.pitch,
+                                bearing: deck.viewState.bearing
+                        };
+                        deck.setProps({});
+                        deck._onViewStateChange({viewState: deck.viewState});
+                        setCentered({lastCenteredSubstation: null, centered: true});
+                    }
                 }
-                setCentered(true);
             }
+
     }
 
     function onViewStateChange(info) {
+        lastViewStateRef.current = info.viewState;
         if (!info.interactionState || // first event of before an animation (e.g. clicking the +/- buttons of the navigation controls, gives the target
             info.interactionState && !info.interactionState.inTransition // Any event not part of a animation (mouse panning or zooming)
         ) {

--- a/src/components/network/network.js
+++ b/src/components/network/network.js
@@ -31,6 +31,8 @@ export default class Network {
 
     voltageLevelsById = new Map();
 
+    substationsById = new Map();
+
     linesByNominalVoltage = new Map();
 
     nominalVoltages = [];
@@ -52,6 +54,9 @@ export default class Network {
 
                 // add count in substation
                 voltageLevel.voltageLevelCount = substation.voltageLevels.length;
+
+                // add the current item into the VL map by id
+                this.substationsById.set(substation.id, substation);
             });
         });
 
@@ -85,6 +90,14 @@ export default class Network {
 
     getVoltageLevel(id) {
         return this.voltageLevelsById.get(id);
+    }
+
+    getSubstations() {
+        return Array.from(this.substationsById.values());
+    }
+
+    getSubstation(id) {
+        return this.substationsById.get(id);
     }
 
     getNominalVoltages() {

--- a/src/components/network/network.test.js
+++ b/src/components/network/network.test.js
@@ -31,16 +31,30 @@ const substations = [
             }
         ]
     }
-]
+];
 
 test('network', () => {
+    // Data initialisation
     const network = new Network();
     network.setSubstations(substations);
+
+    // Substation
     expect(network.substations).toHaveLength(2);
     expect(network.substations[0].id).toEqual("S1");
     expect(network.substations[1].id).toEqual("S2");
+    expect(network.getSubstation("S1")).not.toBeNull();
+    expect(network.getSubstation("S2").id).toEqual("S2");
+    expect(network.getSubstations()).toHaveLength(2);
+
+    // Voltage level
     expect(network.substations[0].voltageLevels[0].id).toEqual("S1_6");
     expect(network.substations[0].voltageLevels[1].id).toEqual("S1_7");
     expect(network.getVoltageLevel("S1_7")).not.toBeNull();
+    expect(network.getVoltageLevel("S2_6").id).toEqual("S2_6");
+    expect(network.getVoltageLevels()).toHaveLength(3);
+
+    // Nominal voltage
     expect(network.voltageLevelsByNominalVoltage.get(225)).toHaveLength(2);
+    expect(network.voltageLevelsByNominalVoltage.get(380)).toHaveLength(1);
+    expect(network.voltageLevelsByNominalVoltage.get(63)).toBeUndefined();
 });

--- a/src/components/study-pane.js
+++ b/src/components/study-pane.js
@@ -202,6 +202,7 @@ const StudyPane = () => {
                                     initialPosition={INITIAL_POSITION}
                                     initialZoom={6}
                                     filteredNominalVoltages={filteredNominalVoltages}
+                                    centeredSubstationId={voltageLevel && voltageLevel.substationId}
                                     onSubstationClick={showVoltageLevelDiagram} />
                         {
                             voltageLevelId &&

--- a/src/components/study-pane.js
+++ b/src/components/study-pane.js
@@ -79,7 +79,9 @@ const StudyPane = () => {
 
     const [studyNotFound, setStudyNotFound] = useState(false);
 
-    const [voltageLevelId, setVoltageLevelId] = useState(null);
+    const [displayedVoltageLevelId, setDisplayedVoltageLevelId] = useState(null);
+
+    const [focusedVoltageLevelId, setFocusedVoltageLevelId] = useState(null);
 
     const [filteredNominalVoltages, setFilteredNominalVoltages] = useState([]);
 
@@ -110,7 +112,7 @@ const StudyPane = () => {
         // parse query parameter
         const queryParams = parse(location.search, { ignoreQueryPrefix: true });
         const newVoltageLevelId = queryParams["voltageLevelId"];
-        setVoltageLevelId(newVoltageLevelId ? newVoltageLevelId : null);
+        setDisplayedVoltageLevelId(newVoltageLevelId ? newVoltageLevelId : null);
     }, [location.search]);
 
     useEffect(() => {
@@ -184,15 +186,21 @@ const StudyPane = () => {
     if (studyNotFound) {
         return <StudyNotFound studyName={studyName}/>;
     } else {
-        let voltageLevel = null;
-        if (voltageLevelId && network) {
-            voltageLevel = network.getVoltageLevel(voltageLevelId);
+        let displayedVoltageLevel, focusedVoltageLevel = null;
+        if (network) {
+            if (displayedVoltageLevelId) {
+                displayedVoltageLevel = network.getVoltageLevel(displayedVoltageLevelId);
+            }
+            if (focusedVoltageLevelId) {
+                focusedVoltageLevel = network.getVoltageLevel(focusedVoltageLevelId);
+            }
         }
         return (
             <Grid container className={classes.main}>
                 <Grid item xs={12} md={2} key="explorer">
                     <NetworkExplorer network={network}
-                                     onVoltageLevelClick={showVoltageLevelDiagram}/>
+                                     onVoltageLevelDisplayClick={ id => showVoltageLevelDiagram(id) }
+                                     onVoltageLevelFocusClick={ id => setFocusedVoltageLevelId(id)} />
                 </Grid>
                 <Grid item xs={12} md={10} key="map">
                     <div style={{position:"relative", width:"100%", height: "100%"}}>
@@ -202,15 +210,15 @@ const StudyPane = () => {
                                     initialPosition={INITIAL_POSITION}
                                     initialZoom={6}
                                     filteredNominalVoltages={filteredNominalVoltages}
-                                    centeredSubstationId={voltageLevel && voltageLevel.substationId}
+                                    centeredSubstationId={focusedVoltageLevel && focusedVoltageLevel.substationId}
                                     onSubstationClick={showVoltageLevelDiagram} />
                         {
-                            voltageLevelId &&
+                            displayedVoltageLevelId &&
                             <div style={{ position: "absolute", left: 10, top: 10, zIndex: 1 }}>
                                 <SingleLineDiagram onClose={() => closeVoltageLevelDiagram()}
                                                    onNextVoltageLevelClick={showVoltageLevelDiagram}
-                                                   diagramTitle={useName && voltageLevel ? voltageLevel.name : voltageLevelId}
-                                                   svgUrl={getVoltageLevelSingleLineDiagram(studyName, voltageLevelId, useName)} />
+                                                   diagramTitle={useName && displayedVoltageLevel ? displayedVoltageLevel.name : displayedVoltageLevelId}
+                                                   svgUrl={getVoltageLevelSingleLineDiagram(studyName, displayedVoltageLevel, useName)} />
                             </div>
                         }
                         {

--- a/src/components/study-pane.js
+++ b/src/components/study-pane.js
@@ -199,7 +199,7 @@ const StudyPane = () => {
             <Grid container className={classes.main}>
                 <Grid item xs={12} md={2} key="explorer">
                     <NetworkExplorer network={network}
-                                     onVoltageLevelDisplayClick={ id => showVoltageLevelDiagram(id) }
+                                     onVoltageLevelDisplayClick={showVoltageLevelDiagram}
                                      onVoltageLevelFocusClick={ id => setFocusedVoltageLevelId(id)} />
                 </Grid>
                 <Grid item xs={12} md={10} key="map">
@@ -218,7 +218,7 @@ const StudyPane = () => {
                                 <SingleLineDiagram onClose={() => closeVoltageLevelDiagram()}
                                                    onNextVoltageLevelClick={showVoltageLevelDiagram}
                                                    diagramTitle={useName && displayedVoltageLevel ? displayedVoltageLevel.name : displayedVoltageLevelId}
-                                                   svgUrl={getVoltageLevelSingleLineDiagram(studyName, displayedVoltageLevel, useName)} />
+                                                   svgUrl={getVoltageLevelSingleLineDiagram(studyName, displayedVoltageLevel.id, useName)} />
                             </div>
                         }
                         {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -40,5 +40,8 @@
 
   "parameters": "Parameters",
   "theme": "Theme",
-  "close": "Close"
+  "close": "Close",
+
+  "centerOnMap": "Center on the map",
+  "openVoltageLevel": "Open the voltage level"
 }

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -39,5 +39,8 @@
 
   "parameters": "Paramètres",
   "theme": "Thème",
-  "close": "Fermer"
+  "close": "Fermer",
+
+  "centerOnMap": "Centrer sur la carte",
+  "openVoltageLevel": "Ouvrir le poste"
 }


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
When clicking on a voltage level, only the svg is update


**What is the new behavior (if this is a feature change)?**
the map is centered on the substation of the voltage level


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

**Other information**:
We can choose what to do when we close the svg, either nothing or zoom back to the whole network. For simplicity, I zoomed back to the whole network.
* We can also choose to not center on a substation during page load if we want to.
* We can also choose to no center on a substation when clicking on the map.
* We can also choose to not center on a substation on svg clicks.
* We can also choose to center on substation not when clicking on a vl in the list, but on a small button next to it, displayed only when selected (or hovered) ?

