### PR TITLE
fix base for multiple slashs in urls

### DIFF
--- a/app-httpd.conf
+++ b/app-httpd.conf
@@ -11,12 +11,12 @@
     </Directory>
 
     RewriteEngine On
-    RewriteMap remapbase "prg:/bin/sed -u -e 's;[^/]*;..;g' -e 's;../..;;' -e 's/.//' -e 's;^$;.;'"
+    RewriteMap remapbase "prg:/bin/sed -u -e 's;[^ ]* ;;' -e 's; .*;;' -e 's;[^/]*;..;g' -e 's;../..;;' -e 's/.//' -e 's;^$;.;'"
 
     RewriteCond /usr/local/apache2/htdocs/study-app%{REQUEST_URI} -f [OR]
     RewriteCond %{REQUEST_URI} ^/api/.*
     RewriteRule ^ - [S=2]
-    RewriteRule ^ "${remapbase:%{REQUEST_URI}}" [DPI]
+    RewriteRule ^ "${remapbase:%{THE_REQUEST}}" [DPI]
     RewriteRule "^(.*)$" /index.html [E=BASE:$1,L]
     SetEnvIf BASE ^$ BASE=.
 


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When browsing https://demo.powsybl.org/study-app/studies//Microgrid%20Be (notice multiple slashs), we get a white page and the javascript is crashed


**What is the new behavior (if this is a feature change)?**
When browsing https://demo.powsybl.org/study-app/studies//Microgrid%20Be (notice multiple slashs), we don't crash and display a proper error



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

**Other information**:
The only remaining bug is when getting real files with multiple slashes, like
https://demo.powsybl.org/study-app///////////index.html