### PR TITLE
Modification of the substation list to adapt to the web browser height

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react-scripts": "3.3.0",
     "react-window": "^1.8.5",
     "redux": "^4.0.5",
-    "typeface-roboto": "0.0.75"
+    "typeface-roboto": "0.0.75",
+    "react-virtualized": "^9.21.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/network/network-explorer.js
+++ b/src/components/network/network-explorer.js
@@ -19,9 +19,11 @@ import ListItem from '@material-ui/core/ListItem';
 import SearchIcon from '@material-ui/icons/Search';
 import TextField from '@material-ui/core/TextField';
 
-import {FixedSizeList} from 'react-window';
+import {FixedSizeList as List} from 'react-window';
 
 import Network from "./network";
+import Divider from "@material-ui/core/Divider";
+import {AutoSizer} from "react-virtualized";
 
 const itemSize = 35;
 
@@ -32,7 +34,7 @@ const useStyles = makeStyles(theme => ({
     },
 }));
 
-const NetworkExplorer = (props) => {
+const NetworkExplorer = ({network, onVoltageLevelClick}) => {
 
     const intl = useIntl();
 
@@ -50,22 +52,22 @@ const NetworkExplorer = (props) => {
     };
 
     useEffect(() => {
-        if (props.network) {
-            setFilteredVoltageLevels(props.network.getVoltageLevels().sort(voltageLevelComparator))
+        if (network) {
+            setFilteredVoltageLevels(network.getVoltageLevels().sort(voltageLevelComparator))
         }
-    }, [props.network]);
+    }, [network]);
 
     useEffect(() => {
         if (currentVoltageLevel !== null) {
-            props.onVoltageLevelClick(currentVoltageLevel.id, currentVoltageLevel.name);
+            onVoltageLevelClick(currentVoltageLevel.id, currentVoltageLevel.name);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [useName]);
 
     function onClickHandler(index) {
-        if (props.onVoltageLevelClick !== null) {
+        if (onVoltageLevelClick !== null) {
             const vl = filteredVoltageLevels[index];
-            props.onVoltageLevelClick(vl.id);
+            onVoltageLevelClick(vl.id);
             setCurrentVoltageLevel(vl);
         }
     }
@@ -78,34 +80,41 @@ const NetworkExplorer = (props) => {
 
     const filter = (event) => {
         const entry = event.target.value.toLowerCase();
-        setFilteredVoltageLevels(props.network.getVoltageLevels().filter(item => {
+        setFilteredVoltageLevels(network.getVoltageLevels().filter(item => {
             const lc = useName ? item.name.toLowerCase() : item.id.toLowerCase();
             return lc.includes(entry);
         }).sort(voltageLevelComparator));
     };
 
     return (
-        <Grid container direction="column">
-            <Grid item xs={12} key="filter">
-                <TextField className={classes.textField} size="small" placeholder={filterMsg} onChange={filter} variant="outlined" InputProps={{
-                    startAdornment: (
-                        <InputAdornment position="start">
-                            <SearchIcon />
-                        </InputAdornment>
-                    ),
-                }} />
-            </Grid>
-            <Grid item xs={12} key="list">
-                <FixedSizeList
-                    height={23 * itemSize}
-                    itemCount={filteredVoltageLevels.length}
-                    itemSize={itemSize}
-                    width="100%"
-                >
-                    {Row}
-                </FixedSizeList>
-            </Grid>
-        </Grid>
+        <AutoSizer>
+            {({width, height}) => (
+                <div style={{width:width, height:height}}>
+                    <Grid container direction="column">
+                        <Grid item>
+                             <TextField className={classes.textField} size="small" placeholder={filterMsg} onChange={filter} variant="outlined" InputProps={{
+                                 startAdornment: (
+                                     <InputAdornment position="start">
+                                         <SearchIcon />
+                                     </InputAdornment>
+                                 ),
+                             }} />
+                        </Grid>
+                        <Divider />
+                        <Grid item>
+                            <List
+                                height={height-57}
+                                itemCount={filteredVoltageLevels.length}
+                                itemSize={itemSize}
+                                width="100%"
+                            >
+                                {Row}
+                            </List>
+                        </Grid>
+                    </Grid>
+                 </div>
+            )}
+        </AutoSizer>
     )
 };
 


### PR DESCRIPTION
Signed-off-by: Mika Theodore <michael.theodore@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Currently the voltage level list in the left-side has a fixed height


**What is the new behavior (if this is a feature change)?**
The voltage level list is adapting with the web browser height


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
