### PR TITLE
Improve rendering performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12016,6 +12016,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
       "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
     "react-map-gl": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-5.2.3.tgz",
@@ -12168,6 +12173,19 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-virtualized": {
+      "version": "9.21.2",
+      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.21.2.tgz",
+      "integrity": "sha512-oX7I7KYiUM7lVXQzmhtF4Xg/4UA5duSA+/ZcAvdWlTLFCoFYq1SbauJT5gZK9cZS/wdYR6TPGpX/dqzvTqQeBA==",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "clsx": "^1.0.1",
+        "dom-helpers": "^5.0.0",
+        "loose-envify": "^1.3.0",
+        "prop-types": "^15.6.0",
+        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "react-virtualized-auto-sizer": {

--- a/src/components/network/network-explorer.js
+++ b/src/components/network/network-explorer.js
@@ -127,4 +127,4 @@ NetworkExplorer.propTypes = {
     onVoltageLevelClick: PropTypes.func
 };
 
-export default NetworkExplorer;
+export default React.memo(NetworkExplorer);

--- a/src/components/network/network-map.js
+++ b/src/components/network/network-map.js
@@ -145,7 +145,7 @@ const NetworkMap = (props) => {
                     getFillColor: color,
                     getRadius: voltageLevel => getVoltageLevelRadius(SUBSTATION_RADIUS, voltageLevel),
                     pickable: true,
-                    visible: props.filteredVoltageLevels.includes(e.nominalVoltage)
+                    visible: props.filteredNominalVoltages.includes(e.nominalVoltage)
                 });
                 layers.push(substationsLayer);
             });
@@ -155,7 +155,7 @@ const NetworkMap = (props) => {
         // present in the filteredVoltageLevels property, in order to handle correctly the substations labels visibility
         let substationsLabelsVisible = [];
         props.network.substations.forEach(substation => {
-            if (substation.voltageLevels.find(v => props.filteredVoltageLevels.includes(v.nominalVoltage)) !== undefined) {
+            if (substation.voltageLevels.find(v => props.filteredNominalVoltages.includes(v.nominalVoltage)) !== undefined) {
                 substationsLabelsVisible.push(substation);
             }
         });
@@ -206,7 +206,7 @@ const NetworkMap = (props) => {
                             pointerY: y
                         });
                     },
-                    visible: props.filteredVoltageLevels.includes(e.nominalVoltage)
+                    visible: props.filteredNominalVoltages.includes(e.nominalVoltage)
                 });
                 layers.push(lineLayer);
             });
@@ -253,7 +253,7 @@ NetworkMap.defaultProps = {
     geoData: null,
     labelsZoomThreshold: 7,
     initialZoom: 5,
-    filteredVoltageLevels: null,
+    filteredNominalVoltages: null,
     initialPosition: [0, 0]
 };
 
@@ -262,9 +262,20 @@ NetworkMap.propTypes = {
     geoData: PropTypes.instanceOf(GeoData),
     labelsZoomThreshold: PropTypes.number.isRequired,
     initialZoom: PropTypes.number.isRequired,
-    filteredVoltageLevels: PropTypes.instanceOf(Array),
+    filteredNominalVoltages: PropTypes.array,
     initialPosition: PropTypes.arrayOf(PropTypes.number).isRequired,
     onSubstationClick: PropTypes.func
 };
 
-export default NetworkMap;
+function areEqual(prevProps, nextProps) {
+    // dont't check for onSubstationClick equality as the function will change at every render
+    // of the parent
+    return prevProps.network === nextProps.network
+        && prevProps.geoData === nextProps.geoData
+        && prevProps.labelsZoomThreshold === nextProps.labelsZoomThreshold
+        && prevProps.initialZoom === nextProps.initialZoom
+        && prevProps.filteredNominalVoltages === nextProps.filteredNominalVoltages
+        && prevProps.initialPosition === nextProps.initialPosition;
+}
+
+export default React.memo(NetworkMap, areEqual);

--- a/src/components/network/network-map.js
+++ b/src/components/network/network-map.js
@@ -267,15 +267,4 @@ NetworkMap.propTypes = {
     onSubstationClick: PropTypes.func
 };
 
-function areEqual(prevProps, nextProps) {
-    // dont't check for onSubstationClick equality as the function will change at every render
-    // of the parent
-    return prevProps.network === nextProps.network
-        && prevProps.geoData === nextProps.geoData
-        && prevProps.labelsZoomThreshold === nextProps.labelsZoomThreshold
-        && prevProps.initialZoom === nextProps.initialZoom
-        && prevProps.filteredNominalVoltages === nextProps.filteredNominalVoltages
-        && prevProps.initialPosition === nextProps.initialPosition;
-}
-
-export default React.memo(NetworkMap, areEqual);
+export default React.memo(NetworkMap);

--- a/src/components/network/network.js
+++ b/src/components/network/network.js
@@ -33,6 +33,8 @@ export default class Network {
 
     linesByNominalVoltage = new Map();
 
+    nominalVoltages = [];
+
     setSubstations(substations) {
         this.substations = substations;
 
@@ -58,6 +60,8 @@ export default class Network {
         this.voltageLevelsByNominalVoltage = this.voltageLevels.reduce(voltageLevelNominalVoltageIndexer, new Map());
 
         this.voltageLevelsById = this.voltageLevels.reduce(voltageLevelIdIndexer, new Map());
+
+        this.nominalVoltages = Array.from(this.voltageLevelsByNominalVoltage.keys()).sort((a, b) => b - a)
     }
 
     setLines(lines) {
@@ -81,5 +85,9 @@ export default class Network {
 
     getVoltageLevel(id) {
         return this.voltageLevelsById.get(id);
+    }
+
+    getNominalVoltages() {
+        return this.nominalVoltages;
     }
 }

--- a/src/components/network/nominal-voltage-filter.js
+++ b/src/components/network/nominal-voltage-filter.js
@@ -92,11 +92,4 @@ NominalVoltageFilter.propTypes = {
     onNominalVoltageFilter: PropTypes.func
 };
 
-function areEqual(prevProps, nextProps) {
-    // dont't check for onNominalVoltageFilter equality as the function will change at every render
-    // of the parent
-    return prevProps.nominalVoltages === nextProps.nominalVoltages
-        && prevProps.filteredNominalVoltages === nextProps.filteredNominalVoltages;
-}
-
-export default React.memo(NominalVoltageFilter, areEqual);
+export default React.memo(NominalVoltageFilter);

--- a/src/components/network/nominal-voltage-filter.js
+++ b/src/components/network/nominal-voltage-filter.js
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import PropTypes from "prop-types";
 
 import {makeStyles} from "@material-ui/core/styles";
@@ -38,23 +38,7 @@ const NominalVoltageFilter = (props) => {
 
     const classes = useStyles();
 
-    const [checkedNominalVoltages, setCheckedNominalVoltages] = useState([]);
-
-    useEffect(() => {
-        setCheckedNominalVoltages(props.filteredNominalVoltages);
-    }, [props.filteredNominalVoltages]);
-
     const handleToggle = value => () => {
-        const currentIndex = checkedNominalVoltages.indexOf(value);
-        const newChecked = [...checkedNominalVoltages];
-
-        if (currentIndex === -1) {
-            newChecked.push(value);
-        } else {
-            newChecked.splice(currentIndex, 1);
-        }
-        setCheckedNominalVoltages(newChecked);
-
         if (props.onNominalVoltageFilter !== null) {
             props.onNominalVoltageFilter(value);
         }
@@ -70,7 +54,7 @@ const NominalVoltageFilter = (props) => {
                             button
                             onClick={handleToggle(value)}
                         >
-                            <Checkbox color="default" className={classes.nominalVoltageCheck} checked={checkedNominalVoltages.indexOf(value) !== -1}/>
+                            <Checkbox color="default" className={classes.nominalVoltageCheck} checked={props.filteredNominalVoltages.indexOf(value) !== -1}/>
                             <ListItemText className={classes.nominalVoltageText} disableTypography primary={`${value}`}/>
                         </ListItem>
                     );
@@ -92,4 +76,4 @@ NominalVoltageFilter.propTypes = {
     onNominalVoltageFilter: PropTypes.func
 };
 
-export default React.memo(NominalVoltageFilter);
+export default NominalVoltageFilter;

--- a/src/components/network/nominal-voltage-filter.js
+++ b/src/components/network/nominal-voltage-filter.js
@@ -10,8 +10,6 @@ import PropTypes from "prop-types";
 
 import {makeStyles} from "@material-ui/core/styles";
 
-import Network from "./network";
-
 import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
 import Checkbox from "@material-ui/core/Checkbox";
@@ -37,18 +35,14 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const NominalVoltageFilter = (props) => {
+
     const classes = useStyles();
+
     const [checkedNominalVoltages, setCheckedNominalVoltages] = useState([]);
-    const [nominalVoltages, setNominalVoltages] = useState([]);
 
     useEffect(() => {
-        if (props.network) {
-            setNominalVoltages(Array.from(props.network.voltageLevelsByNominalVoltage.keys()).sort((a, b) => b - a));
-        }
-        if (props.filteredVoltageLevels) {
-            setCheckedNominalVoltages(props.filteredVoltageLevels);
-        }
-    }, [props.network, props.filteredVoltageLevels]);
+        setCheckedNominalVoltages(props.filteredNominalVoltages);
+    }, [props.filteredNominalVoltages]);
 
     const handleToggle = value => () => {
         const currentIndex = checkedNominalVoltages.indexOf(value);
@@ -69,7 +63,7 @@ const NominalVoltageFilter = (props) => {
     return (
         <Paper>
             <List className={classes.nominalVoltageZone}> {
-                nominalVoltages.map(value => {
+                props.nominalVoltages.map(value => {
                     return (
                         <ListItem className={classes.nominalVoltageItem}
                             key={value}
@@ -87,15 +81,22 @@ const NominalVoltageFilter = (props) => {
 };
 
 NominalVoltageFilter.defaultProps = {
-    network: null,
-    filteredVoltageLevels: null,
+    nominalVoltages: [],
+    filteredNominalVoltages: [],
     onNominalVoltageFilter: null
 };
 
 NominalVoltageFilter.propTypes = {
-    network: PropTypes.instanceOf(Network),
-    filteredVoltageLevels: PropTypes.instanceOf(Array),
+    nominalVoltages: PropTypes.array,
+    filteredNominalVoltages: PropTypes.array,
     onNominalVoltageFilter: PropTypes.func
 };
 
-export default NominalVoltageFilter;
+function areEqual(prevProps, nextProps) {
+    // dont't check for onNominalVoltageFilter equality as the function will change at every render
+    // of the parent
+    return prevProps.nominalVoltages === nextProps.nominalVoltages
+        && prevProps.filteredNominalVoltages === nextProps.filteredNominalVoltages;
+}
+
+export default React.memo(NominalVoltageFilter, areEqual);

--- a/src/components/network/nominal-voltage-filter.js
+++ b/src/components/network/nominal-voltage-filter.js
@@ -39,8 +39,8 @@ const NominalVoltageFilter = (props) => {
     const classes = useStyles();
 
     const handleToggle = value => () => {
-        if (props.onNominalVoltageFilter !== null) {
-            props.onNominalVoltageFilter(value);
+        if (props.onNominalVoltageFilterChange !== null) {
+            props.onNominalVoltageFilterChange(value);
         }
     };
 
@@ -67,13 +67,13 @@ const NominalVoltageFilter = (props) => {
 NominalVoltageFilter.defaultProps = {
     nominalVoltages: [],
     filteredNominalVoltages: [],
-    onNominalVoltageFilter: null
+    onNominalVoltageFilterChange: null
 };
 
 NominalVoltageFilter.propTypes = {
     nominalVoltages: PropTypes.array,
     filteredNominalVoltages: PropTypes.array,
-    onNominalVoltageFilter: PropTypes.func
+    onNominalVoltageFilterChange: PropTypes.func
 };
 
 export default NominalVoltageFilter;

--- a/src/components/study-pane.js
+++ b/src/components/study-pane.js
@@ -169,7 +169,7 @@ const StudyPane = () => {
         history.replace("/studies/" + studyName)
     }
 
-    const filterNominalVoltage = useCallback((vnom) => {
+    const updateNominalVoltageFilter = (vnom) => {
         // filter on nominal voltage
         const currentIndex = filteredNominalVoltages.indexOf(vnom);
         const newFiltered = [...filteredNominalVoltages];
@@ -179,7 +179,7 @@ const StudyPane = () => {
             newFiltered.splice(currentIndex, 1);
         }
         setFilteredNominalVoltages(newFiltered);
-    }, [filteredNominalVoltages, setFilteredNominalVoltages]);
+    };
 
     if (studyNotFound) {
         return <StudyNotFound studyName={studyName}/>;
@@ -217,7 +217,7 @@ const StudyPane = () => {
                             <div style={{position: "absolute", right: 10, bottom: 30, zIndex: 1}}>
                                 <NominalVoltageFilter nominalVoltages={network.getNominalVoltages()}
                                                       filteredNominalVoltages={filteredNominalVoltages}
-                                                      onNominalVoltageFilter={filterNominalVoltage} />
+                                                      onNominalVoltageFilterChange={updateNominalVoltageFilter} />
                             </div>
                         }
                 </div>

--- a/src/components/study-pane.js
+++ b/src/components/study-pane.js
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, {useEffect, useState} from "react";
+import React, {useEffect, useState, useCallback} from "react";
 
 import {useDispatch, useSelector} from "react-redux";
 
@@ -161,15 +161,15 @@ const StudyPane = () => {
             });
     }
 
-    function showVoltageLevelDiagram(voltageLevelId) {
+    const showVoltageLevelDiagram = useCallback((voltageLevelId) => {
         history.replace("/studies/" + studyName + stringify({ voltageLevelId: voltageLevelId }, { addQueryPrefix: true }));
-    }
+    }, []);
 
     function closeVoltageLevelDiagram() {
         history.replace("/studies/" + studyName)
     }
 
-    function filterNominalVoltage(vnom) {
+    const filterNominalVoltage = useCallback((vnom) => {
         // filter on nominal voltage
         const currentIndex = filteredNominalVoltages.indexOf(vnom);
         const newFiltered = [...filteredNominalVoltages];
@@ -179,7 +179,7 @@ const StudyPane = () => {
             newFiltered.splice(currentIndex, 1);
         }
         setFilteredNominalVoltages(newFiltered);
-    }
+    }, [filteredNominalVoltages, setFilteredNominalVoltages]);
 
     if (studyNotFound) {
         return <StudyNotFound studyName={studyName}/>;
@@ -192,7 +192,7 @@ const StudyPane = () => {
             <Grid container className={classes.main}>
                 <Grid item xs={12} md={2} key="explorer">
                     <NetworkExplorer network={network}
-                                     onVoltageLevelClick={ id => showVoltageLevelDiagram(id) }/>
+                                     onVoltageLevelClick={showVoltageLevelDiagram}/>
                 </Grid>
                 <Grid item xs={12} md={10} key="map">
                     <div style={{position:"relative", width:"100%", height: "100%"}}>
@@ -202,12 +202,12 @@ const StudyPane = () => {
                                     initialPosition={INITIAL_POSITION}
                                     initialZoom={6}
                                     filteredNominalVoltages={filteredNominalVoltages}
-                                    onSubstationClick={ id => showVoltageLevelDiagram(id) } />
+                                    onSubstationClick={showVoltageLevelDiagram} />
                         {
                             voltageLevelId &&
                             <div style={{ position: "absolute", left: 10, top: 10, zIndex: 1 }}>
                                 <SingleLineDiagram onClose={() => closeVoltageLevelDiagram()}
-                                                   onNextVoltageLevelClick={ id => showVoltageLevelDiagram(id) }
+                                                   onNextVoltageLevelClick={showVoltageLevelDiagram}
                                                    diagramTitle={useName && voltageLevel ? voltageLevel.name : voltageLevelId}
                                                    svgUrl={getVoltageLevelSingleLineDiagram(studyName, voltageLevelId, useName)} />
                             </div>
@@ -217,7 +217,7 @@ const StudyPane = () => {
                             <div style={{position: "absolute", right: 10, bottom: 30, zIndex: 1}}>
                                 <NominalVoltageFilter nominalVoltages={network.getNominalVoltages()}
                                                       filteredNominalVoltages={filteredNominalVoltages}
-                                                      onNominalVoltageFilter={(vnom) => filterNominalVoltage(vnom)} />
+                                                      onNominalVoltageFilter={filterNominalVoltage} />
                             </div>
                         }
                 </div>

--- a/src/components/study-pane.js
+++ b/src/components/study-pane.js
@@ -169,7 +169,7 @@ const StudyPane = () => {
         history.replace("/studies/" + studyName)
     }
 
-    const updateNominalVoltageFilter = (vnom) => {
+    const updateFilteredNominalVoltages = (vnom) => {
         // filter on nominal voltage
         const currentIndex = filteredNominalVoltages.indexOf(vnom);
         const newFiltered = [...filteredNominalVoltages];
@@ -217,7 +217,7 @@ const StudyPane = () => {
                             <div style={{position: "absolute", right: 10, bottom: 30, zIndex: 1}}>
                                 <NominalVoltageFilter nominalVoltages={network.getNominalVoltages()}
                                                       filteredNominalVoltages={filteredNominalVoltages}
-                                                      onNominalVoltageFilterChange={updateNominalVoltageFilter} />
+                                                      onNominalVoltageFilterChange={updateFilteredNominalVoltages} />
                             </div>
                         }
                 </div>


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Performance improvement


**What is the current behavior?** *(You can also link to an open issue here)*
Opening of single line diagram is very slow for large grids (1 second). The reason is when a single line diagram is open, network map and nominal voltage filtering components are always re-rendered even if their data have not changed.

After analysis it appears that re-rendering is caused by callback props (which are arrow functions) that are always differents at each render because callback functions are recreated at each render of parent component.

A quick reminder: React by default performs to shallow equality of component props to decide if render has to be called again.

With hooks, the common way to implement "shouldComponentUpdate" is using React.memo that allows to implement our own comparator and then exclude callbacks from comparison.



**What is the new behavior (if this is a feature change)?**
NetworkMap and NominalVoltageFilter rendering memoization has been implemented.
Even on large network, single line diagrams are displayed almost instantaneously.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
