### PR TITLE
Use DeckGL CompositeLayer in network map 

### DIFF
--- a/src/components/network/line-layer.js
+++ b/src/components/network/line-layer.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import {CompositeLayer, PathLayer} from 'deck.gl';
+
+class LineLayer extends CompositeLayer {
+
+    renderLayers() {
+        let layers = [];
+
+        if (this.props.network != null && this.props.geoData != null) {
+            // lines : create one layer per nominal voltage, starting from higher to lower nominal voltage
+            this.props.network.getLinesBySortedNominalVoltage()
+                .forEach(e => {
+                    const lineLayer = new PathLayer(this.getSubLayerProps({
+                        id: 'NominalVoltage' + e.nominalVoltage,
+                        data: e.lines,
+                        widthScale: 20,
+                        widthMinPixels: 1,
+                        widthMaxPixels: 2,
+                        getPath: line => this.props.geoData.getLinePositions(this.props.network, line),
+                        getColor: this.props.getNominalVoltageColor(e.nominalVoltage),
+                        getWidth: 2,
+                        visible: this.props.filteredNominalVoltages.includes(e.nominalVoltage)
+                    }));
+                    layers.push(lineLayer);
+                });
+        }
+
+        return layers;
+    }
+}
+
+LineLayer.layerName = 'LineLayer';
+
+LineLayer.defaultProps = {
+    network: null,
+    geoData: null,
+    getNominalVoltageColor: {type: 'accessor', value: [255, 255, 255]},
+    filteredNominalVoltages: [],
+    useName: true
+};
+
+export default LineLayer;

--- a/src/components/network/line-layer.js
+++ b/src/components/network/line-layer.js
@@ -10,7 +10,7 @@ import {CompositeLayer, PathLayer} from 'deck.gl';
 class LineLayer extends CompositeLayer {
 
     renderLayers() {
-        let layers = [];
+        const layers = [];
 
         if (this.props.network != null && this.props.geoData != null) {
             // lines : create one layer per nominal voltage, starting from higher to lower nominal voltage
@@ -41,8 +41,7 @@ LineLayer.defaultProps = {
     network: null,
     geoData: null,
     getNominalVoltageColor: {type: 'accessor', value: [255, 255, 255]},
-    filteredNominalVoltages: [],
-    useName: true
+    filteredNominalVoltages: []
 };
 
 export default LineLayer;

--- a/src/components/network/network-map.js
+++ b/src/components/network/network-map.js
@@ -7,6 +7,9 @@
 
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+
+import {useSelector} from "react-redux";
+
 import {_MapContext as MapContext, NavigationControl, StaticMap} from 'react-map-gl';
 import DeckGL from '@deck.gl/react';
 import {PathLayer, ScatterplotLayer, TextLayer} from '@deck.gl/layers';
@@ -16,7 +19,7 @@ import {decomposeColor} from '@material-ui/core/styles/colorManipulator';
 
 import Network from './network';
 import GeoData from './geo-data';
-import {useSelector} from "react-redux";
+import {getNominalVoltageColor} from '../../utils/colors'
 
 const MAPBOX_TOKEN = 'pk.eyJ1IjoiZ2VvZmphbWciLCJhIjoiY2pwbnRwcm8wMDYzMDQ4b2pieXd0bDMxNSJ9.Q4aL20nBo5CzGkrWtxroug'; // eslint-disable-line
 
@@ -38,24 +41,6 @@ const NetworkMap = (props) => {
     const theme = useTheme();
 
     const useName = useSelector(state => state.useName);
-
-    function getNominalVoltageColor(nominalVoltage) {
-        if (nominalVoltage >= 300) {
-            return [255, 0, 0];
-        } else if (nominalVoltage >= 170 && nominalVoltage < 300) {
-            return [34, 139, 34];
-        } else if (nominalVoltage >= 120 && nominalVoltage < 170) {
-            return [1, 175, 175];
-        } else if (nominalVoltage >= 70 && nominalVoltage < 120) {
-            return [204, 85, 0];
-        } else if (nominalVoltage >= 50 && nominalVoltage < 70) {
-            return [160, 32, 240];
-        } else if (nominalVoltage >= 30 && nominalVoltage < 50) {
-            return [255, 130, 144];
-        } else {
-            return [171, 175, 40];
-        }
-    }
 
     // Do this in onAfterRender because when doing it in useEffect (triggered by calling setDeck()),
     // it doesn't work in the case of using the browser backward/forward buttons (because in this particular case,
@@ -130,9 +115,7 @@ const NetworkMap = (props) => {
 
     if (props.network !== null && props.geoData !== null) {
         // substations : create one layer per nominal voltage, starting from higher to lower nominal voltage
-        Array.from(props.network.voltageLevelsByNominalVoltage.entries())
-            .map(e => { return { nominalVoltage: e[0], voltageLevels: e[1] };})
-            .sort((a, b) => b.nominalVoltage - a.nominalVoltage)
+        props.network.getVoltageLevelsBySortedNominalVoltage()
             .forEach(e => {
                 const color = getNominalVoltageColor(e.nominalVoltage);
 
@@ -153,12 +136,8 @@ const NetworkMap = (props) => {
         // substations labels : create one layer
         // First, we construct the substations where there is at least one voltage level with a nominal voltage
         // present in the filteredVoltageLevels property, in order to handle correctly the substations labels visibility
-        let substationsLabelsVisible = [];
-        props.network.substations.forEach(substation => {
-            if (substation.voltageLevels.find(v => props.filteredNominalVoltages.includes(v.nominalVoltage)) !== undefined) {
-                substationsLabelsVisible.push(substation);
-            }
-        });
+        const substationsLabelsVisible = props.network.substations
+            .filter(substation => substation.voltageLevels.find(v => props.filteredNominalVoltages.includes(v.nominalVoltage)) !== undefined);
 
         const labelColor = decomposeColor(theme.palette.text.primary).values;
         labelColor[3] *= 255;
@@ -170,6 +149,7 @@ const NetworkMap = (props) => {
             getPosition: substation => props.geoData.getSubstationPosition(substation.id),
             getText: substation => useName ? substation.name : substation.id,
             getColor: labelColor,
+            fontFamily: 'Roboto',
             getSize: 16,
             getAngle: 0,
             getTextAnchor: 'start',
@@ -183,9 +163,7 @@ const NetworkMap = (props) => {
         layers.push(substationLabelsLayer);
 
         // lines : create one layer per nominal voltage, starting from higher to lower nominal voltage
-        Array.from(props.network.linesByNominalVoltage.entries())
-            .map(e => { return { nominalVoltage: e[0], lines: e[1] };})
-            .sort((a, b) => b.nominalVoltage - a.nominalVoltage)
+        props.network.getLinesBySortedNominalVoltage()
             .forEach(e => {
                 const color = getNominalVoltageColor(e.nominalVoltage);
 

--- a/src/components/network/network-map.js
+++ b/src/components/network/network-map.js
@@ -132,7 +132,7 @@ const NetworkMap = (props) => {
         }
     }
 
-    let layers = [];
+    const layers = [];
 
     if (props.network !== null && props.geoData !== null) {
 
@@ -157,7 +157,6 @@ const NetworkMap = (props) => {
             geoData: props.geoData,
             getNominalVoltageColor: getNominalVoltageColor,
             filteredNominalVoltages: props.filteredNominalVoltages,
-            useName: useName,
             pickable: true,
             onHover: ({object, x, y}) => {
                 setTooltip({

--- a/src/components/network/network-map.js
+++ b/src/components/network/network-map.js
@@ -120,7 +120,8 @@ const NetworkMap = (props) => {
             filteredNominalVoltages: props.filteredNominalVoltages,
             useName: useName,
             labelsVisible: labelsVisible,
-            labelColor: labelColor
+            labelColor: labelColor,
+            pickable: true
         }));
 
         layers.push(new LineLayer({
@@ -130,6 +131,7 @@ const NetworkMap = (props) => {
             getNominalVoltageColor: getNominalVoltageColor,
             filteredNominalVoltages: props.filteredNominalVoltages,
             useName: useName,
+            pickable: true,
             onHover: ({object, x, y}) => {
                 setTooltip({
                     message: object ? (useName ? object.name : object.id) : null,

--- a/src/components/network/network.js
+++ b/src/components/network/network.js
@@ -90,4 +90,16 @@ export default class Network {
     getNominalVoltages() {
         return this.nominalVoltages;
     }
+
+    getVoltageLevelsBySortedNominalVoltage() {
+        return Array.from(this.voltageLevelsByNominalVoltage.entries())
+            .map(e => { return { nominalVoltage: e[0], voltageLevels: e[1] };})
+            .sort((a, b) => b.nominalVoltage - a.nominalVoltage);
+    }
+
+    getLinesBySortedNominalVoltage() {
+        return Array.from(this.linesByNominalVoltage.entries())
+            .map(e => { return { nominalVoltage: e[0], lines: e[1] };})
+            .sort((a, b) => b.nominalVoltage - a.nominalVoltage);
+    }
 }

--- a/src/components/network/substation-layer.js
+++ b/src/components/network/substation-layer.js
@@ -16,7 +16,7 @@ function getVoltageLevelRadius(substationRadius, voltageLevel) {
 class SubstationLayer extends CompositeLayer {
 
     renderLayers() {
-        let layers = [];
+        const layers = [];
 
         if (this.props.network != null && this.props.geoData != null) {
             // substations : create one layer per nominal voltage, starting from higher to lower nominal voltage

--- a/src/components/network/substation-layer.js
+++ b/src/components/network/substation-layer.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import {CompositeLayer, ScatterplotLayer, TextLayer} from 'deck.gl';
+
+const SUBSTATION_RADIUS = 500;
+
+function getVoltageLevelRadius(substationRadius, voltageLevel) {
+    return substationRadius / voltageLevel.voltageLevelCount * (voltageLevel.voltageLevelIndex + 1)
+}
+
+class SubstationLayer extends CompositeLayer {
+
+    renderLayers() {
+        let layers = [];
+
+        if (this.props.network != null && this.props.geoData != null) {
+            // substations : create one layer per nominal voltage, starting from higher to lower nominal voltage
+            this.props.network.getVoltageLevelsBySortedNominalVoltage()
+                .forEach(e => {
+                    // substations
+                    const substationsLayer = new ScatterplotLayer(this.getSubLayerProps({
+                        id: 'NominalVoltage' + e.nominalVoltage,
+                        data: e.voltageLevels,
+                        radiusMinPixels: 1,
+                        getPosition: voltageLevel => this.props.geoData.getSubstationPosition(voltageLevel.substationId),
+                        getFillColor: this.props.getNominalVoltageColor(e.nominalVoltage),
+                        getRadius: voltageLevel => getVoltageLevelRadius(SUBSTATION_RADIUS, voltageLevel),
+                        visible: this.props.filteredNominalVoltages.includes(e.nominalVoltage)
+                    }));
+                    layers.push(substationsLayer);
+                });
+
+            // substations labels : create one layer
+            // First, we construct the substations where there is at least one voltage level with a nominal voltage
+            // present in the filteredVoltageLevels property, in order to handle correctly the substations labels visibility
+            const substationsLabelsVisible = this.props.network.substations
+                .filter(substation => substation.voltageLevels.find(v => this.props.filteredNominalVoltages.includes(v.nominalVoltage)) !== undefined);
+
+            const substationLabelsLayer = new TextLayer(this.getSubLayerProps({
+                id: "Label",
+                data: substationsLabelsVisible,
+                getPosition: substation => this.props.geoData.getSubstationPosition(substation.id),
+                getText: substation => this.props.useName ? substation.name : substation.id,
+                getColor: this.props.labelColor,
+                fontFamily: 'Roboto',
+                getSize: 16,
+                getAngle: 0,
+                getTextAnchor: 'start',
+                getAlignmentBaseline: 'center',
+                getPixelOffset: [20, 0],
+                visible: this.props.labelsVisible,
+                updateTriggers: {
+                    getText: this.props.useName
+                }
+            }));
+            layers.push(substationLabelsLayer);
+        }
+
+        return layers;
+    }
+}
+
+SubstationLayer.layerName = 'SubstationLayer';
+
+SubstationLayer.defaultProps = {
+    network: null,
+    geoData: null,
+    getNominalVoltageColor: {type: 'accessor', value: [255, 255, 255]},
+    filteredNominalVoltages: [],
+    useName: true,
+    labelsVisible: false,
+    labelColor: {type: 'color', value: [255, 255, 255]}
+};
+
+export default SubstationLayer;

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+export function getNominalVoltageColor(nominalVoltage) {
+    if (nominalVoltage >= 300) {
+        return [255, 0, 0];
+    } else if (nominalVoltage >= 170 && nominalVoltage < 300) {
+        return [34, 139, 34];
+    } else if (nominalVoltage >= 120 && nominalVoltage < 170) {
+        return [1, 175, 175];
+    } else if (nominalVoltage >= 70 && nominalVoltage < 120) {
+        return [204, 85, 0];
+    } else if (nominalVoltage >= 50 && nominalVoltage < 70) {
+        return [160, 32, 240];
+    } else if (nominalVoltage >= 30 && nominalVoltage < 50) {
+        return [255, 130, 144];
+    } else {
+        return [171, 175, 40];
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
Network  map layer are not organized and all created in NetworkMap component.


**What is the new behavior (if this is a feature change)?**
DeckGL has composite layer that allows implementing custom layers based on composition of standard layers.
I created 2 business layer: 
  - substation layer: that embed everything regarding substation representation (including substation label)
  - line layer: for lines display


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
